### PR TITLE
Rework errors

### DIFF
--- a/src/handler/notificationHandler.ts
+++ b/src/handler/notificationHandler.ts
@@ -1,6 +1,6 @@
 ﻿import * as express from 'express';
 import Handler from './handler';
-import Notification from '../types/notification'
+import Notification, { INotification } from '../types/notification'
 import Log from '../log';
 import * as utils from '../utils';
 import {WebSocketManager} from "../webSocketManager";
@@ -20,67 +20,92 @@ export default class NotificationHandler extends Handler {
     }
 
     private async getNotifications(req: express.Request, res: express.Response): Promise<void> {
+        let limit: number = (req.query.limit) ? Number(req.query.limit) : 100; // TODO set default limit in config
+        let skip: number = (req.query.skip) ? Number(req.query.skip) : 0;
+        let criteria: any = { userId: req.session.user.id, isArchived: false }
+        if (req.query.subscription)
+            criteria.subscription = req.query.subscription;
+        if (!req.query.includeDone || req.query.includeDone === "false")
+            criteria.isDone = false;
+        
+        let arr: INotification[];
         try {
-            let limit: number = (req.query.limit) ? Number(req.query.limit) : 100; // TODO set default limit in config
-            let skip: number = (req.query.skip) ? Number(req.query.skip) : 0;
-            let criteria: any = { userId: req.session.user.id, isArchived: false }
-            if (req.query.subscription)
-                criteria.subscription = req.query.subscription;
-            if (!req.query.includeDone || req.query.includeDone === "false")
-                criteria.isDone = false;
-            
-            let arr = await Notification.find(criteria).sort({timestamp: -1}).skip(skip).limit(limit);
-            res.json(arr);
+            arr = await Notification.find(criteria).sort({timestamp: -1}).skip(skip).limit(limit);
         } catch (e) {
-            utils.handleError(e, log, res);
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
         }
+        res.json(arr);
     }
 
     private async markNotificationsAsDone(req: express.Request, res: express.Response): Promise<void> {
+        let notification: INotification | null;
         try {
-            let notification = await Notification.findOneAndUpdate({ _id: req.body.id, userId: req.session.user.id }, { isDone: true });
-            if (!notification)
-                throw new Error("Could not find notification");
-
-            this.webSocketManager.loadAndUpdateNotificationInBackground(notification._id, req.session.user.id, req.session.id);
-            log.info("Marked as done: " + JSON.stringify(notification));
-            res.json({
-                "status": "success"
-            });
+            notification = await Notification.findOneAndUpdate({ _id: req.body.id, userId: req.session.user.id }, { isDone: true });
         } catch (e) {
-            utils.handleError(e, log, res);
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
         }
+
+        if (!notification) {
+            log.warn("Could not find notification");
+            utils.writeError("Could not find notification", res);
+            return;
+        }
+
+        this.webSocketManager.loadAndUpdateNotificationInBackground(notification._id, req.session.user.id, req.session.id);
+        log.info("Marked as done: " + JSON.stringify(notification));
+        res.json({
+            "status": "success"
+        });
     }
 
     private async markNotificationsAsUndone(req: express.Request, res: express.Response): Promise<void> {
+        let notification: INotification | null;
         try {
-            let notification = await Notification.findOneAndUpdate({ _id: req.body.id, userId: req.session.user.id }, { isDone: false });
-            if (!notification)
-                throw new Error("Could not find notification");
-
-            this.webSocketManager.loadAndUpdateNotificationInBackground(notification._id, req.session.user.id, req.session.id);
-            log.info("Marked as undone: " + JSON.stringify(notification));
-            res.json({
-                "status": "success"
-            });
+            notification = await Notification.findOneAndUpdate({ _id: req.body.id, userId: req.session.user.id }, { isDone: false });
         } catch (e) {
-            utils.handleError(e, log, res);
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
         }
+
+        if (!notification) {
+            log.warn("Could not find notification");
+            utils.writeError("Could not find notification", res);
+            return;
+        }
+        
+        this.webSocketManager.loadAndUpdateNotificationInBackground(notification._id, req.session.user.id, req.session.id);
+        log.info("Marked as undone: " + JSON.stringify(notification));
+        res.json({
+            "status": "success"
+        });
     }
 
     private async deleteNotifications(req: express.Request, res: express.Response): Promise<void> {
+        let notification: INotification | null;
         try {
-            let notification = await Notification.findOneAndUpdate({ _id: req.query.id, userId: req.session.user.id }, { isArchived: true });
-            if (!notification)
-                throw new Error("Could not find notification");
-            this.webSocketManager.deleteNotification(notification._id, req.session.user.id, req.session.id);
-            log.info("Deleted notification: " + JSON.stringify(notification));
-            res.json({
-                "status": "success"
-            });
+            notification = await Notification.findOneAndUpdate({ _id: req.query.id, userId: req.session.user.id }, { isArchived: true });
         } catch (e) {
-            utils.handleError(e, log, res);
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
         }
+
+        if (!notification) {
+            log.warn("Could not find notification");
+            utils.writeError("Could not find notification", res);
+            return;
+        }
+        
+        this.webSocketManager.deleteNotification(notification._id, req.session.user.id, req.session.id);
+        log.info("Deleted notification: " + JSON.stringify(notification));
+        res.json({
+            "status": "success"
+        });
 
     }
 }

--- a/src/handler/spHandler.ts
+++ b/src/handler/spHandler.ts
@@ -1,8 +1,8 @@
 ﻿import * as express from 'express';
 import Handler from './handler';
-import App from '../types/app';
-import Notification from '../types/notification';
-import Subscription from '../types/subscription';
+import App, {IApp} from '../types/app';
+import Notification, { INotification } from '../types/notification';
+import Subscription, { ISubscription } from '../types/subscription';
 import Log from '../log';
 import * as utils from '../utils';
 import {WebSocketManager} from "../webSocketManager";
@@ -23,87 +23,137 @@ export default class SPHandler extends Handler {
     }
 
     private async postApp(req: express.Request, res: express.Response): Promise<void> {
+        App.sanitize(req.body, false);
+
+        let app: IApp;
         try {
-            App.sanitize(req.body, false);
-            let app = await App.create(req.body);
-            log.info("Created app: " + JSON.stringify(app));
-            res.json({
-                "status": "success",
-                "id": app._id
-            });
+            app = await App.create(req.body);
         } catch (e) {
-            utils.handleError(e, log, res);
+            log.error(e.message)
+            utils.writeDBError(e, res);
+            return
         }
+
+        log.info("Created app: " + JSON.stringify(app));
+        res.json({
+            "status": "success",
+            "id": app._id
+        });
     }
 
     private async putApp(req: express.Request, res: express.Response): Promise<void> {
+        let app: IApp | null;
         try {
-            let app = await App.findById(req.body.id);
-            if (!app)
-                throw new Error("Could not find app");
-            let data = await utils.decryptContent(app.cert, req.body.content);
-            if (data === undefined) {
-                utils.handleError(new Error("Could not verify"), log, res);
-                return;
-            }
-            App.sanitize(data, true);
-            await app.updateOne(data);
-            this.webSocketManager.loadAndUpdateSubscriptionsForAppInBackground(app._id);
-            log.info("Updated app: " + JSON.stringify(app));
-            res.json({
-                "status": "success"
-            });
+            app = await App.findById(req.body.id);
         } catch (e) {
-            utils.handleError(e, log, res);
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
         }
+
+        if (!app) {
+            log.warn("Could not find app");
+            utils.writeError("Could not find app", res);
+            return;
+        }
+
+        let data = await utils.decryptContent(app.cert, req.body.content);
+        if (data === undefined) {
+            log.warn("Could not verify");
+            utils.writeError("Could not verify", res);
+            return;
+        }
+
+        App.sanitize(data, true);
+        try {
+            await app.updateOne(data);
+        } catch (e) {
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
+        }
+
+        this.webSocketManager.loadAndUpdateSubscriptionsForAppInBackground(app._id);
+        log.info("Updated app: " + JSON.stringify(app));
+        res.json({
+            "status": "success"
+        });
     }
 
     private async postNotification(req: express.Request, res: express.Response): Promise<void> {
+        let subscription: ISubscription | null;
         try {
-            let subscription = await Subscription.findById(req.body.subscriptionId);
-            if (!subscription)
-                throw new Error("No valid subscription");
-            Notification.sanitize(req.body.notification, false);
-            req.body.notification.userId = subscription.userId;
-            req.body.notification.subscription = subscription._id;
-            let notification = await Notification.create(req.body.notification);
-            this.webSocketManager.createNotification(notification, subscription.userId);
-            log.info("Created notification: " + JSON.stringify(notification));
-            res.json({
-                "status": "success",
-                "id": notification._id
-            });
+            subscription = await Subscription.findById(req.body.subscriptionId);
         } catch (e) {
-            utils.handleError(e, log, res);
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
         }
+
+        if (!subscription) {
+            log.warn("No valid subscription");
+            utils.writeError("No valid subscription", res);
+            return;
+        }
+
+        Notification.sanitize(req.body.notification, false);
+        req.body.notification.userId = subscription.userId;
+        req.body.notification.subscription = subscription._id;
+        let notification: INotification;
+        try {
+            notification = await Notification.create(req.body.notification);
+        } catch (e) {
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
+        }
+
+        this.webSocketManager.createNotification(notification, subscription.userId);
+        log.info("Created notification: " + JSON.stringify(notification));
+        res.json({
+            "status": "success",
+            "id": notification._id
+        });
     }
 
     private async putNotification(req: express.Request, res: express.Response): Promise<void> {
+        Notification.sanitize(req.body.notification, false);
+        let notification: INotification | null;
         try {
-            Notification.sanitize(req.body.notification, false);
-            let notification = await Notification.findByIdAndUpdate(req.body.id, req.body.notification);
-            this.webSocketManager.loadAndUpdateNotificationInBackground(req.body.id);
-            log.info("Updated notification: " + JSON.stringify(notification));
-            res.json({
-                "status": "success"
-            });
+            notification = await Notification.findByIdAndUpdate(req.body.id, req.body.notification);
         } catch (e) {
-            utils.handleError(e, log, res);
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
         }
+
+        this.webSocketManager.loadAndUpdateNotificationInBackground(req.body.id);
+        log.info("Updated notification: " + JSON.stringify(notification));
+        res.json({
+            "status": "success"
+        });
     }
 
     private async deleteNotification(req: express.Request, res: express.Response): Promise<void> {
+        let notification: INotification | null;
         try {
-            let notification = await Notification.findByIdAndDelete(req.query.id);
-            if (notification != null) {
-                this.webSocketManager.deleteNotification(notification._id, notification.userId);
-            }
-            log.info("Deleted notification: " + JSON.stringify(notification));
-            res.json({
-                "status": "success"
-            });
+            notification = await Notification.findByIdAndDelete(req.query.id);
         } catch (e) {
-            utils.handleError(e, log, res);
+            log.error(e.message);
+            utils.writeDBError(e, res);
+            return;
         }
+
+        if (!notification) {
+            log.warn("Could not find notification");
+            utils.writeError("Could not find notification", res);
+            return;
+        }
+
+        this.webSocketManager.deleteNotification(notification._id, notification.userId);
+        log.info("Deleted notification: " + JSON.stringify(notification));
+        res.json({
+            "status": "success"
+        });
     }
 }

--- a/src/handler/userHandler.ts
+++ b/src/handler/userHandler.ts
@@ -16,15 +16,11 @@ export default class UserHandler extends Handler {
     }
 
     private async getUser(req: express.Request, res: express.Response): Promise<void> {
-        try {
-            res.json({
-                "firstName": req.session.user.firstName,
-                "lastName": req.session.user.lastName,
-                "email": req.session.user.email
-            });
-            log.info("Got user information");
-        } catch (e) {
-            utils.handleError(e, log, res);
-        }
+        res.json({
+            "firstName": req.session.user.firstName,
+            "lastName": req.session.user.lastName,
+            "email": req.session.user.email
+        });
+        log.info("Got user information");
     }
 }

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -2,7 +2,7 @@
 import ISanitizer from './sanitizer';
 import { isUrl, isEmail } from '../utils';
 
-interface IApp extends mongoose.Document {
+export interface IApp extends mongoose.Document {
     name: string;
     imageUrl: string;
     isHidden: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,11 +7,6 @@ import Log from './log';
 
 const logger = new Log("Utils");
 
-export function handleError(err: Error, log: Log, res: express.Response, statusCode: number = 400) {
-    log.error(err.message);
-    writeError(err.message, res, statusCode);
-}
-
 export function writeDBError(err: mongoose.Error, res: express.Response) {
     let reason: string;
     let code: number = 400;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,10 +8,14 @@ const logger = new Log("Utils");
 
 export function handleError(err: Error, log: Log, res: express.Response, statusCode: number = 400) {
     log.error(err.message);
-    res.status(statusCode);
+    writeError(err.message, res, statusCode);
+}
+
+export function writeError(reason: string, res: express.Response, code:number = 400) {
+    res.status(code);
     res.json({
         "status": "error",
-        "reason": err.message
+        "reason": reason
     });
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@
 import * as crypto from 'crypto';
 import validator from 'validator';
 import * as jwt from 'jsonwebtoken';
+import * as mongoose from 'mongoose';
 import Log from './log';
 
 const logger = new Log("Utils");
@@ -9,6 +10,30 @@ const logger = new Log("Utils");
 export function handleError(err: Error, log: Log, res: express.Response, statusCode: number = 400) {
     log.error(err.message);
     writeError(err.message, res, statusCode);
+}
+
+export function writeDBError(err: mongoose.Error, res: express.Response) {
+    let reason: string;
+    let code: number = 400;
+    if (err instanceof mongoose.Error.ValidationError) {
+        let paths: string[] = [];
+        Object.keys(err.errors).forEach((key: string, i: number) => {
+            let error: mongoose.Error.ValidatorError | mongoose.Error.CastError = err.errors[key];
+            if (error.kind === "required")
+                paths.push(error.path + ": required");
+            else if (error.kind === "user defined")
+                paths.push(error.path + ": invalid data");
+            else
+                paths.push(error.path + ": invalid");
+        });
+        reason = paths.join(", ");
+    } else if (err instanceof mongoose.Error.CastError) {
+        reason = "Invalid id";
+    } else {
+        reason = "Internal Server Error";
+        code = 500;
+    }
+    writeError(reason, res, code);
 }
 
 export function writeError(reason: string, res: express.Response, code:number = 400) {


### PR DESCRIPTION
although this introduces a lot more code into the individual handlers, it is now clearer what can actually throw errors. furthermore the number of `throw`s is now greatly reduced.
although i don't think the parsing of the db errors is particualrily pretty, i couldn't come up with a better solution as the individual error cases are very dynamic. if our api is used more by outside users there might even be new kinds of errors i need to account for. at least the current implementation lends itself for extensibility. 

it would be great if you could provide your optinion on this change.
once we are both satisfied i'll merge the branch to keep the commit history cleaner for our prof.

on a side note: i only touched the handler code. the error handling inside the main and config needs rework too but i'll postpone that for now.